### PR TITLE
Set revocation token exception and  configurable default values for connectTimeout, readTimeout jwks retriever

### DIFF
--- a/src/main/java/org/seedstack/oauth/OAuthConfig.java
+++ b/src/main/java/org/seedstack/oauth/OAuthConfig.java
@@ -23,6 +23,7 @@ import java.util.Set;
 public class OAuthConfig {
     @NotNull
     private ProviderConfig provider = new ProviderConfig();
+    private RetrieverConfig retriever = new RetrieverConfig();
     @NotNull
     private AlgorithmConfig algorithms = new AlgorithmConfig();
     private URI discoveryDocument;
@@ -223,7 +224,15 @@ public class OAuthConfig {
         return this;
     }
 
-    @Config("provider")
+    public RetrieverConfig getRetriever() {
+		return retriever;
+	}
+
+	public void setRetriever(RetrieverConfig retriever) {
+		this.retriever = retriever;
+	}
+
+	@Config("provider")
     public static class ProviderConfig {
         private URI authorization;
         private URI token;
@@ -317,5 +326,24 @@ public class OAuthConfig {
             this.plainTokenAllowed = plainTokenAllowed;
             return this;
         }
+    }
+    @Config("retriever")
+    public static class RetrieverConfig {
+        private String connectTimeout;
+        private String readTimeout;
+		public String getConnectTimeout() {
+			return connectTimeout;
+		}
+		public void setConnectTimeout(String connectTimeout) {
+			this.connectTimeout = connectTimeout;
+		}
+		public String getReadTimeout() {
+			return readTimeout;
+		}
+		public void setReadTimeout(String readTimeout) {
+			this.readTimeout = readTimeout;
+		}
+       
+
     }
 }

--- a/src/main/java/org/seedstack/oauth/internal/OAuthServiceImpl.java
+++ b/src/main/java/org/seedstack/oauth/internal/OAuthServiceImpl.java
@@ -332,8 +332,6 @@ public class OAuthServiceImpl implements OAuthService {
             	  throw new TokenValidationException("Unable to validate the access token (HTTP status " 
             + userInfoResponse.toErrorResponse().getErrorObject().getHTTPStatusCode() + "): " +
             			  userInfoResponse.toErrorResponse().getErrorObject().getDescription());
-                //LOGGER.warn("Unable to fetch user info: {}", OAuthUtils.buildGenericError(((ErrorResponse) userInfoResponse)).getDescription());
-               // return Optional.empty();
             }
         }
         return Optional.empty();

--- a/src/main/java/org/seedstack/oauth/internal/OAuthServiceImpl.java
+++ b/src/main/java/org/seedstack/oauth/internal/OAuthServiceImpl.java
@@ -16,6 +16,7 @@ import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
 import com.nimbusds.jwt.*;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
@@ -178,14 +179,11 @@ public class OAuthServiceImpl implements OAuthService {
 
         // Signing key selector
         oauthProvider.getJwksEndpoint().ifPresent(jwksEndpoint -> {
-            try {
-                JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(jwksEndpoint.toURL());
+                JWKSource<SecurityContext> keySource = getkeySource(jwksEndpoint);
                 JWSAlgorithm expectedAlg = JWSAlgorithm.parse(oauthConfig.algorithms().getAccessSigningAlgorithm());
                 JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedAlg, keySource);
                 jwtProcessor.setJWSKeySelector(keySelector);
-            } catch (MalformedURLException e) {
-                throw new TokenValidationException("Invalid JWKS endpoint: " + e.getMessage());
-            }
+           
         });
 
         // Claims verification
@@ -218,6 +216,24 @@ public class OAuthServiceImpl implements OAuthService {
         } catch (BadJOSEException | JOSEException e) {
             throw new TokenValidationException("Unable to validate JWT access token: " + e.getMessage(), e);
         }
+    }
+    
+    private JWKSource<SecurityContext> getkeySource(URI jwksEndpoint){
+    	try {
+    		JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(jwksEndpoint.toURL());
+    		String connectTimeout =oauthConfig.getRetriever().getConnectTimeout();
+    		String readTimeOut=oauthConfig.getRetriever().getReadTimeout();
+    			if(connectTimeout!=null &&connectTimeout!="" &&
+    					readTimeOut!=null && readTimeOut!="") {
+    				DefaultResourceRetriever defaultResourceRetriever= 
+    	        			new DefaultResourceRetriever(Integer.parseInt(connectTimeout),
+    	        					Integer.parseInt(readTimeOut));
+    				keySource = new RemoteJWKSet<>(jwksEndpoint.toURL(),defaultResourceRetriever);
+    			}
+    			return keySource;
+			} catch (MalformedURLException e) {
+				 throw new TokenValidationException("Invalid JWKS endpoint: " + e.getMessage());
+			}
     }
 
     private JWTClaimsSet validateOpaqueAccessToken(AccessToken accessToken) {
@@ -313,8 +329,11 @@ public class OAuthServiceImpl implements OAuthService {
             if (userInfoResponse.indicatesSuccess()) {
                 return Optional.of(((UserInfoSuccessResponse) userInfoResponse).getUserInfo());
             } else {
-                LOGGER.warn("Unable to fetch user info: {}", OAuthUtils.buildGenericError(((ErrorResponse) userInfoResponse)).getDescription());
-                return Optional.empty();
+            	  throw new TokenValidationException("Unable to validate the access token (HTTP status " 
+            + userInfoResponse.toErrorResponse().getErrorObject().getHTTPStatusCode() + "): " +
+            			  userInfoResponse.toErrorResponse().getErrorObject().getDescription());
+                //LOGGER.warn("Unable to fetch user info: {}", OAuthUtils.buildGenericError(((ErrorResponse) userInfoResponse)).getDescription());
+               // return Optional.empty();
             }
         }
         return Optional.empty();

--- a/src/main/java/org/seedstack/oauth/internal/OAuthServiceImpl.java
+++ b/src/main/java/org/seedstack/oauth/internal/OAuthServiceImpl.java
@@ -223,8 +223,8 @@ public class OAuthServiceImpl implements OAuthService {
     		JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(jwksEndpoint.toURL());
     		String connectTimeout =oauthConfig.getRetriever().getConnectTimeout();
     		String readTimeOut=oauthConfig.getRetriever().getReadTimeout();
-    			if(connectTimeout!=null &&connectTimeout!="" &&
-    					readTimeOut!=null && readTimeOut!="") {
+    			if(connectTimeout!=null && ! connectTimeout.equals("") &&
+    					readTimeOut!=null && ! readTimeOut.equals("")) {
     				DefaultResourceRetriever defaultResourceRetriever= 
     	        			new DefaultResourceRetriever(Integer.parseInt(connectTimeout),
     	        					Integer.parseInt(readTimeOut));


### PR DESCRIPTION
fixed: adding configurable default values for connectTimeout, readTimeout jwks retriever
fixed: setting revocation token exception not fired when ocurrs

To use the custom connectTimeOut and readTimeout, you can use the the following example parameters in security.yml:
oauth:
...
 retriever:
      connectTimeout: 1000
      readTimeout: 1000
